### PR TITLE
avoids duplicate BAS rows for the same company

### DIFF
--- a/erpnext_australian_localisation/overrides/company.py
+++ b/erpnext_australian_localisation/overrides/company.py
@@ -1,23 +1,43 @@
 import frappe
+from frappe import _
 
 
-def initial_company_setup(company=None):
+def initial_company_setup(company: str | None = None) -> None:
 	if company:
 		company_list = [company]
 	else:
-		company_list = frappe.get_list("Company", filters={"country": "Australia"}, pluck="name")
+		company_list = frappe.get_all(
+			"Company",
+			filters={"country": "Australia"},
+			pluck="name",
+		)
 
-	au_localisation_settings = frappe.get_cached_doc("AU Localisation Settings")
+	if not company_list:
+		frappe.logger().info("No Australian companies found for BAS setup.")
+		return
 
-	for c in company_list:
-		child = frappe.new_doc("AU BAS Reporting Period")
-		child.update({"company": c, "reporting_period": "Monthly"})
+	au_settings = frappe.get_cached_doc("AU Localisation Settings")
 
-		au_localisation_settings.append("bas_reporting_period", child)
+	for comp in company_list:
+		exists = any(d.company == comp for d in au_settings.bas_reporting_period)
+		if exists:
+			continue
 
-		au_localisation_settings.save()
+		au_settings.append("bas_reporting_period", {
+			"company": comp,
+			"reporting_period": "Monthly",
+		})
+
+	if au_settings.is_dirty():
+		au_settings.save(ignore_permissions=True)
+		frappe.msgprint(
+			_("BAS Reporting Periods initialised for {0}").format(", ".join(company_list))
+		)
 
 
-def after_insert(doc, event):
+def after_insert(doc, event: str) -> None:
+	"""
+	Hook: After inserting a Company, auto-create BAS setup if it's in Australia.
+	"""
 	if doc.country == "Australia":
 		initial_company_setup(doc.name)

--- a/erpnext_australian_localisation/overrides/company.py
+++ b/erpnext_australian_localisation/overrides/company.py
@@ -36,8 +36,5 @@ def initial_company_setup(company: str | None = None) -> None:
 
 
 def after_insert(doc, event: str) -> None:
-	"""
-	Hook: After inserting a Company, auto-create BAS setup if it's in Australia.
-	"""
 	if doc.country == "Australia":
 		initial_company_setup(doc.name)


### PR DESCRIPTION
saves settings only if something was added.useful feedback in desk / logs.ensures system setup works even if user has limited rights. no repeated DB calls.