### PR TITLE
fix: refuse account numbers longer than 9 digits in ABA file generation

### DIFF
--- a/erpnext_australian_localisation/erpnext_australian_localisation/doctype/payment_batch/aba_file_generator.py
+++ b/erpnext_australian_localisation/erpnext_australian_localisation/doctype/payment_batch/aba_file_generator.py
@@ -3,6 +3,24 @@ from datetime import datetime
 import frappe
 from frappe import _
 
+ABA_ACCOUNT_WIDTH = 9
+
+
+def aba_account_field(bank_account_no, owner):
+	"""Return the account number padded to the 9-character ABA field.
+
+	Supplier, Employee and Bank Account store up to 10 digits, but the ABA
+	detail record holds 9. A longer number is refused here rather than cut
+	to nine digits, which would pay a different account.
+	"""
+	if len(bank_account_no) > ABA_ACCOUNT_WIDTH:
+		frappe.throw(
+			_("Bank account number for {0} has {1} digits; an ABA file allows at most {2}.").format(
+				owner, len(bank_account_no), ABA_ACCOUNT_WIDTH
+			)
+		)
+	return bank_account_no.rjust(ABA_ACCOUNT_WIDTH)
+
 
 @frappe.whitelist()
 def generate_aba_file(payment_batch):
@@ -60,7 +78,10 @@ def generate_aba_file(payment_batch):
 			)
 
 		if party_account_details.bank_account_no:
-			content += party_account_details.bank_account_no[0:9].rjust(9)
+			content += aba_account_field(
+				party_account_details.bank_account_no,
+				f"{payment_entry.party_type} {payment_entry.party}",
+			)
 		else:
 			frappe.throw(
 				_("Bank account number not found for {0} {1}").format(
@@ -80,7 +101,7 @@ def generate_aba_file(payment_batch):
 			frappe.throw(_("Branch code not found for Bank Account {0}").format(payment_batch.bank_account))
 
 		if bank_account.bank_account_no:
-			content += bank_account.bank_account_no[0:9].rjust(9)
+			content += aba_account_field(bank_account.bank_account_no, payment_batch.bank_account)
 		else:
 			frappe.throw(
 				_("Bank account number not found for Bank Account {0}").format(payment_batch.bank_account)

--- a/erpnext_australian_localisation/erpnext_australian_localisation/doctype/payment_batch/test_payment_batch.py
+++ b/erpnext_australian_localisation/erpnext_australian_localisation/doctype/payment_batch/test_payment_batch.py
@@ -1,9 +1,19 @@
 # Copyright (c) 2025, frappe.dev@arus.co.in and Contributors
 # See license.txt
 
-# import frappe
+import frappe
 from frappe.tests.utils import FrappeTestCase
+
+from erpnext_australian_localisation.erpnext_australian_localisation.doctype.payment_batch.aba_file_generator import (
+	aba_account_field,
+)
 
 
 class TestPaymentBatch(FrappeTestCase):
-	pass
+	def test_aba_account_field_pads_to_nine(self):
+		self.assertEqual(aba_account_field("123456", "Supplier S-0001"), "   123456")
+		self.assertEqual(aba_account_field("123456789", "Supplier S-0001"), "123456789")
+
+	def test_aba_account_field_refuses_ten_digits(self):
+		with self.assertRaises(frappe.ValidationError):
+			aba_account_field("1234567890", "Supplier S-0001")


### PR DESCRIPTION
Supplier, Employee and Bank Account accept 6 to 10 digit account numbers (`bank_details_validation` regex, custom field length 10, patch `update_bank_account_no_field_length`), but the ABA detail record holds 9 characters. `generate_aba_file` sliced every account number to nine digits, so a ten-digit number was written to the file as a different account with no error.

This change adds one helper, `aba_account_field`, that refuses numbers longer than 9 digits and names the party or bank account in the message, and uses it for both the receiver account and the trace account. Two tests cover padding and refusal. The 10-digit validation is left as is, since it was widened deliberately; the ABA file is the only place the limit is 9.

Checked with ruff (check and format) against the repo config.
