### PR TITLE
Fix BAS credits for private and input-taxed purchases

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ bench install-app erpnext_australian_localisation
   - Sales amounts are reported in G1 based on GL Entries.
 - The final 1A and 1B label amounts will be reported to arrive at the amount business needs to pay the ATO or the amount ATO will refund the business
 - BAS reports can be generated Monthly / Quarterly
+- Full BAS excludes private and input-taxed purchase GST from 1B and includes it in G13/G15. Mixed eligibility requires ERPNext v16 item tax records that reconcile to the company-currency tax total. Split partly private acquisitions into separately supported business and private invoice rows.
+- Simpler BAS stops when the period contains private or input-taxed purchase entries because its ledger totals cannot apply those item exclusions. Use the full reporting method after reconciling the entries. Financial-acquisition and reduced-credit exceptions require separate assessment.
+- After updating purchase allocation, reconcile and regenerate affected existing invoice BAS entries and draft reports. Previously submitted BAS reports and ledger postings are not amended automatically.
 - BAS reports (detailed information with transactional document number) can be printed in PDF format
 - Payment Proposal (Batch) generation for Supplier / Employee Payment
 - ABA File generation for the Payment Batch which can be used to upload into the online banking system for bulk payments for the suppliers / employees

--- a/erpnext_australian_localisation/erpnext_australian_localisation/doctype/au_bas_report/au_bas_report.py
+++ b/erpnext_australian_localisation/erpnext_australian_localisation/doctype/au_bas_report/au_bas_report.py
@@ -51,7 +51,7 @@ def validate_reporting_scope(doc):
 
 
 @frappe.whitelist()
-def get_gst(name):
+def get_gst(name: str):
 	"""
 	Update the BAS Report G labels based on the reporting method
 	"""

--- a/erpnext_australian_localisation/erpnext_australian_localisation/doctype/au_bas_report/au_bas_report.py
+++ b/erpnext_australian_localisation/erpnext_australian_localisation/doctype/au_bas_report/au_bas_report.py
@@ -11,6 +11,7 @@ from frappe.model.document import Document
 
 class AUBASReport(Document):
 	def before_submit(self):
+		validate_reporting_scope(self)
 		if self.reporting_status != "Validated":
 			frappe.throw(_("Only BAS Report at Validated state can be submitted"))
 
@@ -32,12 +33,30 @@ class AUBASReport(Document):
 				frappe.throw(_("BAS Report found for this period"))
 
 
+def validate_reporting_scope(doc):
+	if doc.reporting_method != "Full reporting method" and frappe.db.exists(
+		"AU BAS Entry",
+		{
+			"company": doc.company,
+			"date": ["between", [doc.start_date, doc.end_date]],
+			"tax_code": ["in", ["AUPPVTUSE", "AUPINPTAX"]],
+		},
+	):
+		frappe.throw(
+			_(
+				"This period contains private or input-taxed purchases. Simpler BAS ledger totals cannot "
+				"apply their item exclusions. Reconcile the purchase entries and use the full reporting method."
+			)
+		)
+
+
 @frappe.whitelist()
 def get_gst(name):
 	"""
 	Update the BAS Report G labels based on the reporting method
 	"""
 	doc = frappe.get_doc("AU BAS Report", name)
+	validate_reporting_scope(doc)
 	doc.bas_updation_datetime = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S")
 
 	frappe.publish_realtime("bas_data_generator", user=frappe.session.user)

--- a/erpnext_australian_localisation/erpnext_australian_localisation/doctype/au_bas_report/test_bas_scope.py
+++ b/erpnext_australian_localisation/erpnext_australian_localisation/doctype/au_bas_report/test_bas_scope.py
@@ -1,0 +1,59 @@
+from unittest import TestCase
+from unittest.mock import patch
+
+import frappe
+
+from erpnext_australian_localisation.erpnext_australian_localisation.doctype.au_bas_report import (
+	au_bas_report as bas,
+)
+
+
+class Record(dict):
+	def __getattr__(self, name):
+		return self.get(name, 0)
+
+	def __setattr__(self, name, value):
+		self[name] = value
+
+	def append(self, field, value):
+		self.setdefault(field, []).append(value)
+
+	def save(self, **kwargs):
+		pass
+
+
+class TestBASScope(TestCase):
+	def test_simpler_report_refuses_item_exclusions_that_its_gl_totals_cannot_apply(self):
+		doc = Record(
+			company="Example",
+			accounting_basis="Non-cash",
+			reporting_method="Simpler",
+			start_date="2026-07-01",
+			end_date="2026-07-31",
+		)
+		with patch.object(frappe.db, "get_value", return_value="AUD"):
+			with patch.object(frappe.db, "exists", return_value=None):
+				bas.validate_reporting_scope(doc)
+			with (
+				patch.object(frappe.db, "exists", return_value="EXCLUDED-PURCHASE"),
+				self.assertRaises(frappe.ValidationError),
+			):
+				bas.validate_reporting_scope(doc)
+			doc.reporting_method = "Full reporting method"
+			with patch.object(frappe.db, "exists", return_value="EXCLUDED-PURCHASE"):
+				bas.validate_reporting_scope(doc)
+
+	def test_generation_and_submission_refuse_excluded_simpler_report(self):
+		doc = Record(
+			company="Example",
+			reporting_method="Simpler",
+			reporting_status="Validated",
+			start_date="2026-07-01",
+			end_date="2026-07-31",
+		)
+		with patch.object(frappe.db, "exists", return_value="EXCLUDED-PURCHASE"):
+			with self.assertRaises(frappe.ValidationError):
+				bas.AUBASReport.before_submit(doc)
+			with patch.object(frappe, "get_doc", return_value=doc):
+				with self.assertRaises(frappe.ValidationError):
+					bas.get_gst("EXAMPLE-REPORT")

--- a/erpnext_australian_localisation/overrides/invoices.py
+++ b/erpnext_australian_localisation/overrides/invoices.py
@@ -45,9 +45,7 @@ def before_submit(doc, event):
 				else "Subjected"
 			)
 			allocations = [(tax.au_tax_code, round(tax.base_tax_amount_after_discount_amount, 2))]
-			if doc.doctype == "Purchase Invoice" and any(
-				item.au_tax_code in {"AUPPVTUSE", "AUPINPTAX"} for item in doc.items
-			):
+			if doc.doctype == "Purchase Invoice":
 				allocations = get_purchase_tax_allocations(doc, tax)
 			for tax_code, amount in allocations:
 				# Excluded GST forms part of the purchase and its G13/G15 exclusion.
@@ -65,7 +63,11 @@ def get_purchase_tax_allocations(doc, tax):
 	"""Use ERPNext v16's company-currency item tax amounts for mixed eligibility."""
 	cent = Decimal("0.01")
 	total = Decimal(str(tax.base_tax_amount_after_discount_amount)).quantize(cent, rounding=ROUND_HALF_UP)
+	if tax.get("add_deduct_tax") == "Deduct":
+		total = -total
 	codes = {item.au_tax_code for item in doc.items}
+	if not codes & {"AUPPVTUSE", "AUPINPTAX"}:
+		return [(tax.au_tax_code, float(total))]
 	if len(codes) == 1:
 		return [(next(iter(codes)), float(total))]
 

--- a/erpnext_australian_localisation/overrides/invoices.py
+++ b/erpnext_australian_localisation/overrides/invoices.py
@@ -1,3 +1,5 @@
+from decimal import ROUND_HALF_UP, Decimal, InvalidOperation
+
 import frappe
 import pandas as pd
 
@@ -42,18 +44,67 @@ def before_submit(doc, event):
 				if frappe.db.get_value("Account", tax.account_head, "account_type") == "Tax"
 				else "Subjected"
 			)
-			result.extend(
-				generate_bas_labels(
-					tax_management,
-					tax_allocation,
-					tax.au_tax_code,
-					tax.account_head,
-					round(tax.tax_amount_after_discount_amount, 2),
-					sum_depends_on[1],
+			allocations = [(tax.au_tax_code, round(tax.base_tax_amount_after_discount_amount, 2))]
+			if doc.doctype == "Purchase Invoice" and any(
+				item.au_tax_code in {"AUPPVTUSE", "AUPINPTAX"} for item in doc.items
+			):
+				allocations = get_purchase_tax_allocations(doc, tax)
+			for tax_code, amount in allocations:
+				# Excluded GST forms part of the purchase and its G13/G15 exclusion.
+				management = "Subjected" if tax_code in {"AUPPVTUSE", "AUPINPTAX"} else tax_management
+				result.extend(
+					generate_bas_labels(
+						management, tax_allocation, tax_code, tax.account_head, amount, sum_depends_on[1]
+					)
 				)
-			)
 
 		create_au_bas_entries(doc.doctype, doc.name, doc.company, doc.posting_date, result, sum_depends_on)
+
+
+def get_purchase_tax_allocations(doc, tax):
+	"""Use ERPNext v16's company-currency item tax amounts for mixed eligibility."""
+	cent = Decimal("0.01")
+	total = Decimal(str(tax.base_tax_amount_after_discount_amount)).quantize(cent, rounding=ROUND_HALF_UP)
+	codes = {item.au_tax_code for item in doc.items}
+	if len(codes) == 1:
+		return [(next(iter(codes)), float(total))]
+
+	message = frappe._(
+		"Mixed purchase GST requires item tax amounts that reconcile to the company-currency tax total. "
+		"Recalculate the invoice taxes and check each item's eligibility before submitting."
+	)
+	try:
+		item_codes = {id(item): item.au_tax_code for item in doc.items}
+		seen = set()
+		amounts = {}
+		for row in getattr(doc, "_item_wise_tax_details", None) or []:
+			if row.tax is not tax:
+				continue
+			key = id(row.item)
+			if key not in item_codes or key in seen:
+				raise ValueError
+			seen.add(key)
+			amount = Decimal(str(row.amount))
+			if not amount.is_finite():
+				raise ValueError
+			code = item_codes[key]
+			amounts[code] = amounts.get(code, Decimal(0)) + amount
+		if seen != set(item_codes) or sum(amounts.values()).quantize(cent, rounding=ROUND_HALF_UP) != total:
+			raise ValueError
+	except (ValueError, TypeError, InvalidOperation):
+		frappe.throw(message)
+
+	allocated = {code: amount.quantize(cent, rounding=ROUND_HALF_UP) for code, amount in amounts.items()}
+	residual = total - sum(allocated.values())
+	for code in sorted(amounts, key=lambda code: abs(amounts[code]), reverse=True):
+		if not residual:
+			break
+		adjustment = (
+			max(-allocated[code], residual) if amounts[code] >= 0 else min(-allocated[code], residual)
+		)
+		allocated[code] += adjustment
+		residual -= adjustment
+	return [(code, float(amount)) for code, amount in allocated.items()]
 
 
 # Generate BAS Labels for the given tax_allocation, au_tax_code and account

--- a/erpnext_australian_localisation/overrides/test_invoices.py
+++ b/erpnext_australian_localisation/overrides/test_invoices.py
@@ -1,0 +1,234 @@
+from types import SimpleNamespace
+from unittest import TestCase
+from unittest.mock import patch
+
+import frappe
+
+from erpnext_australian_localisation.erpnext_australian_localisation.doctype.au_bas_report import (
+	au_bas_report as bas,
+)
+from erpnext_australian_localisation.overrides import invoices
+from erpnext_australian_localisation.setup.install_fixtures import get_au_bas_label_setup
+
+
+class Row(dict):
+	def __getattr__(self, name):
+		return self.get(name)
+
+	def __setattr__(self, name, value):
+		self[name] = value
+
+	def save(self, **kwargs):
+		pass
+
+	def append(self, field, value):
+		self.setdefault(field, []).append(value)
+
+
+class TestPurchaseGSTEligibility(TestCase):
+	def purchase(self, items, tax_amount=100, detail=None):
+		doc = SimpleNamespace(
+			doctype="Purchase Invoice",
+			name="EXAMPLE-1",
+			company="Example",
+			posting_date="2026-07-01",
+			taxes_and_charges="GST",
+			conversion_rate=1.5,
+			items=[Row(expense_account="Expense", **item) for item in items],
+			taxes=[
+				Row(
+					account_head="GST",
+					base_tax_amount_after_discount_amount=tax_amount,
+					tax_amount_after_discount_amount=tax_amount / 1.5,
+				)
+			],
+		)
+		for index, item in enumerate(doc.items):
+			item.name = f"item-{index}"
+		doc._item_wise_tax_details = []
+		for key, value in (detail or {}).items():
+			item = next((item for item in doc.items if key in (item.name, item.item_code)), Row())
+			doc._item_wise_tax_details.append(
+				Row(
+					item=item,
+					tax=doc.taxes[0],
+					amount=value[1] if isinstance(value, list) and len(value) == 2 else "invalid",
+				)
+			)
+		created = []
+
+		def new_doc(doctype):
+			self.assertEqual(doctype, "AU BAS Entry")
+			row = Row()
+			created.append(row)
+			return row
+
+		def get_value(doctype, filters, field):
+			if doctype == "Company":
+				return "AUD"
+			if doctype == "Account":
+				return "Tax"
+			if doctype in ("Item Tax Template", "Purchase Taxes and Charges Template"):
+				return filters
+			if doctype == "AU Tax Determination":
+				return "AUPNCAFR" if filters.get("item_tax_template") == "GST-free" else "AUPNCASGT"
+			raise AssertionError(doctype)
+
+		def labels(doctype, filters, fields):
+			self.assertEqual(doctype, "AU BAS Label Setup")
+			return [
+				Row(bas_label=row["bas_label"])
+				for row in get_au_bas_label_setup()
+				if all(row.get(key) == value for key, value in filters.items())
+			]
+
+		with (
+			patch.object(frappe.db, "get_value", side_effect=get_value),
+			patch.object(frappe, "get_all", side_effect=labels),
+			patch.object(frappe, "new_doc", side_effect=new_doc),
+		):
+			invoices.before_submit(doc, "before_submit")
+		totals = {}
+		for row in created:
+			totals[row.bas_label] = (
+				totals.get(row.bas_label, 0)
+				+ row.get("gst_offset_basis", 0)
+				+ row.get("gst_offset_amount", 0)
+			)
+		self.created = created
+		return totals
+
+	def test_full_report_keeps_only_the_eligible_invoice_credit(self):
+		labels = ["G1", "G2", "G3", "G4", "G7", "G10", "G11", "G13", "G14", "G15", "G18", "1A", "1B"]
+		for flag, exclusion in [("private_use", "g15"), ("input_taxed", "g13")]:
+			with self.subTest(flag=flag):
+				self.purchase(
+					[
+						{"item_code": "P", "base_net_amount": 300, flag: 1},
+						{"item_code": "B", "base_net_amount": 700},
+					],
+					detail={"P": [10, 30], "B": [10, 70]},
+				)
+				report = Row(company="Example", start_date="2026-07-01", end_date="2026-07-31")
+
+				def entries(doctype, filters, pluck):
+					self.assertEqual(doctype, "AU BAS Entry")
+					label = next(value for field, operator, value in filters if field == "bas_label")
+					return [str(i) for i, row in enumerate(self.created) if row.bas_label == label]
+
+				def mapped(doctype, name, *args, **kwargs):
+					row = Row(gst_pay_basis=0, gst_pay_amount=0, gst_offset_basis=0, gst_offset_amount=0)
+					row.update(self.created[int(name)])
+					return row
+
+				with (
+					patch.object(frappe, "get_all", return_value=labels),
+					patch.object(frappe, "get_list", side_effect=entries),
+					patch.object(frappe.db, "get_value", return_value="AUD"),
+					patch.object(frappe, "publish_progress"),
+					patch("frappe.model.mapper.get_mapped_doc", side_effect=mapped),
+				):
+					bas.update_full_bas_report(report)
+				self.assertEqual(report.get("1b"), 70)
+				self.assertEqual(report.g20, 70)
+				self.assertEqual(report.g11, 1100)
+				self.assertEqual(report.get(exclusion), 330)
+
+	def test_private_and_input_taxed_purchases_have_no_credit(self):
+		for flag, label in [("private_use", "G15"), ("input_taxed", "G13")]:
+			with self.subTest(flag=flag):
+				totals = self.purchase([{"item_code": "A", "base_net_amount": 1000, flag: 1}])
+				self.assertEqual(totals.get("1B", 0), 0)
+				self.assertEqual(totals["G11"], 1100)
+				self.assertEqual(totals[label], 1100)
+
+	def test_ordinary_purchase_keeps_its_credit(self):
+		self.assertEqual(
+			self.purchase([{"item_code": "A", "base_net_amount": 1000}]), {"1B": 100, "G11": 1100}
+		)
+
+	def test_mixed_purchase_uses_item_tax_in_company_currency(self):
+		totals = self.purchase(
+			[
+				{"item_code": "P", "base_net_amount": 300, "private_use": 1},
+				{"item_code": "B", "base_net_amount": 700},
+			],
+			detail={"P": [10, 30], "B": [10, 70]},
+		)
+		self.assertEqual(totals, {"1B": 70, "G11": 1100, "G15": 330})
+
+	def test_gst_free_business_item_does_not_receive_private_items_tax(self):
+		totals = self.purchase(
+			[
+				{"item_code": "P", "base_net_amount": 300, "private_use": 1},
+				{"item_code": "B", "base_net_amount": 700, "item_tax_template": "GST-free"},
+			],
+			tax_amount=30,
+			detail={"P": [10, 30], "B": [0, 0]},
+		)
+		self.assertEqual(totals, {"G11": 1030, "G14": 700, "G15": 330})
+
+	def test_mixed_credit_note_reverses_only_the_eligible_credit(self):
+		totals = self.purchase(
+			[
+				{"item_code": "P", "base_net_amount": -300, "private_use": 1},
+				{"item_code": "B", "base_net_amount": -700},
+			],
+			tax_amount=-100,
+			detail={"P": [10, -30], "B": [10, -70]},
+		)
+		self.assertEqual(totals, {"1B": -70, "G11": -1100, "G15": -330})
+
+	def test_mixed_purchase_refuses_missing_or_unreconciled_item_tax(self):
+		for detail in [
+			None,
+			{},
+			{"P": [10, 30]},
+			{"P": [10, 30], "B": [10, 90]},
+			{"P": [10, "NaN"], "B": [10, 70]},
+			{"P": [10, 30], "B": "invalid"},
+		]:
+			with self.subTest(detail=detail), self.assertRaises(frappe.ValidationError):
+				self.purchase(
+					[
+						{"item_code": "P", "base_net_amount": 300, "private_use": 1},
+						{"item_code": "B", "base_net_amount": 700},
+					],
+					detail=detail,
+				)
+
+	def test_zero_net_tax_preserves_the_business_credit(self):
+		totals = self.purchase(
+			[
+				{"item_code": "P", "base_net_amount": -300, "private_use": 1},
+				{"item_code": "B", "base_net_amount": 300},
+			],
+			tax_amount=0,
+			detail={"P": [10, -30], "B": [10, 30]},
+		)
+		self.assertEqual(totals, {"1B": 30, "G11": 0, "G15": -330})
+
+	def test_fractional_item_tax_reconciles_for_purchases_and_returns(self):
+		for sign in (1, -1):
+			with self.subTest(sign=sign):
+				totals = self.purchase(
+					[
+						{"item_code": "P", "base_net_amount": sign * 0.05, "private_use": 1},
+						{"item_code": "B", "base_net_amount": sign * 0.05},
+					],
+					tax_amount=sign * 0.01,
+					detail={"P": [10, sign * 0.005], "B": [10, sign * 0.005]},
+				)
+				self.assertAlmostEqual(totals["G11"], sign * 0.11)
+				self.assertAlmostEqual(totals["G15"], sign * 0.05)
+				self.assertAlmostEqual(totals["1B"], sign * 0.01)
+
+	def test_same_item_code_with_separate_rows_preserves_eligibility(self):
+		totals = self.purchase(
+			[
+				{"item_code": "A", "base_net_amount": 300, "private_use": 1},
+				{"item_code": "A", "base_net_amount": 700},
+			],
+			detail={"item-0": [10, 30], "item-1": [10, 70]},
+		)
+		self.assertEqual(totals, {"1B": 70, "G11": 1100, "G15": 330})

--- a/erpnext_australian_localisation/overrides/test_invoices.py
+++ b/erpnext_australian_localisation/overrides/test_invoices.py
@@ -26,7 +26,7 @@ class Row(dict):
 
 
 class TestPurchaseGSTEligibility(TestCase):
-	def purchase(self, items, tax_amount=100, detail=None):
+	def purchase(self, items, tax_amount=100, detail=None, add_deduct_tax="Add"):
 		doc = SimpleNamespace(
 			doctype="Purchase Invoice",
 			name="EXAMPLE-1",
@@ -38,6 +38,7 @@ class TestPurchaseGSTEligibility(TestCase):
 			taxes=[
 				Row(
 					account_head="GST",
+					add_deduct_tax=add_deduct_tax,
 					base_tax_amount_after_discount_amount=tax_amount,
 					tax_amount_after_discount_amount=tax_amount / 1.5,
 				)
@@ -146,6 +147,43 @@ class TestPurchaseGSTEligibility(TestCase):
 		self.assertEqual(
 			self.purchase([{"item_code": "A", "base_net_amount": 1000}]), {"1B": 100, "G11": 1100}
 		)
+
+	def test_deducted_tax_reduces_ordinary_purchase_credit(self):
+		for sign in (1, -1):
+			with self.subTest(sign=sign):
+				self.assertEqual(
+					self.purchase(
+						[{"item_code": "B", "base_net_amount": sign * 1000}],
+						tax_amount=sign * 100,
+						add_deduct_tax="Deduct",
+					),
+					{"1B": sign * -100, "G11": sign * 900},
+				)
+
+	def test_deducted_tax_preserves_mixed_and_single_exclusions(self):
+		for flag, label in [("private_use", "G15"), ("input_taxed", "G13")]:
+			for sign in (1, -1):
+				with self.subTest(flag=flag, sign=sign):
+					self.assertEqual(
+						self.purchase(
+							[
+								{"item_code": "P", "base_net_amount": sign * 300, flag: 1},
+								{"item_code": "B", "base_net_amount": sign * 700},
+							],
+							tax_amount=sign * 100,
+							add_deduct_tax="Deduct",
+							detail={"P": [10, sign * -30], "B": [10, sign * -70]},
+						),
+						{"1B": sign * -70, "G11": sign * 900, label: sign * 270},
+					)
+					self.assertEqual(
+						self.purchase(
+							[{"item_code": "P", "base_net_amount": sign * 1000, flag: 1}],
+							tax_amount=sign * 100,
+							add_deduct_tax="Deduct",
+						),
+						{"G11": sign * 900, label: sign * 900},
+					)
 
 	def test_mixed_purchase_uses_item_tax_in_company_currency(self):
 		totals = self.purchase(


### PR DESCRIPTION
Private and input-taxed purchase items currently receive GST credits that their eligibility excludes. Use ERPNext v16 item tax records to allocate mixed invoices, preserve total purchases and put excluded amounts in G13/G15. Refuse Simpler BAS for affected periods because its ledger totals cannot apply item exclusions.

Fourteen regressions pass locally and on the native Frappe server in CI, including mixed invoices, credit notes, deducted tax, repeated item codes, zero-net tax and cent rounding. The invoice-to-full-report case reports a $70 credit from a $1,100 purchase containing $330 of excluded items. Pinned Ruff 0.8.1 lint and formatting checks and the hosted dependency audit pass.

Reconcile historical invoice BAS entries before regenerating affected draft reports. This change does not amend submitted reports or ledger postings. Production migration and accountant sign-off remain unverified.
